### PR TITLE
change the notebook image user to standard $NB_USER

### DIFF
--- a/builds/pb-jupyter-datascience.dockerfile
+++ b/builds/pb-jupyter-datascience.dockerfile
@@ -23,7 +23,7 @@ RUN chmod a+x /usr/local/bin/autodownload_and_start.sh
 # compatibility with old blueprints, remove when not needed
 RUN ln -s /usr/local/bin/autodownload_and_start.sh /usr/local/bin/bootstrap_and_start.bash
 
-USER 1000
+USER $NB_USER
 
 CMD ["/usr/local/bin/autodownload_and_start.sh"]
 

--- a/builds/pb-jupyter-minimal.dockerfile
+++ b/builds/pb-jupyter-minimal.dockerfile
@@ -18,6 +18,6 @@ ENV HOME /home/$NB_USER
 COPY scripts/jupyter/autodownload_and_start.sh /usr/local/bin/autodownload_and_start.sh
 RUN chmod a+x /usr/local/bin/autodownload_and_start.sh
 
-USER 1001
+USER $NB_USER
 
 CMD ["/usr/local/bin/autodownload_and_start.sh"]

--- a/builds/pb-jupyter-ml.dockerfile
+++ b/builds/pb-jupyter-ml.dockerfile
@@ -23,6 +23,8 @@ RUN echo "graphviz from apt" \
     && apt-get install -y graphviz \
     && apt-get clean
 
+USER $NB_USER
+
 RUN echo "upgrade pip and setuptools" \
     && pip --no-cache-dir install --upgrade pip setuptools
 
@@ -47,18 +49,14 @@ RUN echo "Scikit-Image" \
 RUN echo "Graphviz" \
     && pip --no-cache-dir install graphviz
 
-USER 1001
-
 RUN echo "Theano and Keras" \
     && pip --no-cache-dir install Theano \
     && pip --no-cache-dir install PyYAML seaborn keras \
     && true
 
-
 RUN echo "MNIST image database prepopulation" \
     && mkdir -p ~/.keras/datasets/ \
     && wget https://s3.amazonaws.com/img-datasets/mnist.pkl.gz -O ~/.keras/datasets/mnist.pkl.gz
-
 
 RUN echo "pydot and pydot-ng" \
     && pip --no-cache-dir install pydot pydot-ng\

--- a/builds/pb-jupyter-ml.dockerfile
+++ b/builds/pb-jupyter-ml.dockerfile
@@ -29,16 +29,15 @@ RUN echo "upgrade pip and setuptools" \
     && pip --no-cache-dir install --upgrade pip setuptools
 
 RUN echo "Tensorflow" \
-    && pip --no-cache-dir install tensorflow==2.0.0-rc0
+    && pip --no-cache-dir install tensorflow==2.0.0
 
 RUN echo "Scikit-Learn" \
     && pip --no-cache-dir install sklearn
 
-RUN echo "PyTorch" \
-    && pip --no-cache-dir install http://download.pytorch.org/whl/cpu/torch-1.1.0-cp37-cp37m-linux_x86_64.whl
-
-RUN echo "TorchVision" \
-    && pip --no-cache-dir install torchvision
+RUN echo "PyTorch, TorchVision and ipywidgets" \
+    && pip --no-cache-dir install torch==1.4.0+cpu torchvision==0.5.0+cpu \
+       -f https://download.pytorch.org/whl/torch_stable.html \
+    && pip --no-cache-dir install ipywidgets==7.5.1
 
 RUN echo "Xgboost" \
     && pip --no-cache-dir install xgboost

--- a/builds/pb-jupyter-pyspark.dockerfile
+++ b/builds/pb-jupyter-pyspark.dockerfile
@@ -18,8 +18,6 @@ ENV HOME /home/$NB_USER
 COPY scripts/jupyter/autodownload_and_start.sh /usr/local/bin/autodownload_and_start.sh
 RUN chmod a+x /usr/local/bin/autodownload_and_start.sh
 
-# this change likely makes this container incompatible with openshift
-# but it appears necessary for pyspark to run
-USER 1000
+USER $NB_USER
 
 CMD ["/usr/local/bin/autodownload_and_start.sh"]


### PR DESCRIPTION
Instead of specifying a fixed UID for the notebook user make use
of the predefined $NB_USER from the upstream image. This will help
with package installations.

Bonus: update tensorflow, pytorch and torchvision.