### PR TITLE
Add ssh and less

### DIFF
--- a/builds/build_config.yaml
+++ b/builds/build_config.yaml
@@ -7,7 +7,7 @@ spec:
   source:
     type: Git
     git:
-      uri: 'https://github.com/CSC-IT-Center-for-Science/notebook-images.git'
+      uri: "https://github.com/CSCfi/notebook-images.git"
       ref: master
     contextDir: builds
   strategy:

--- a/builds/pb-jupyter-datascience.dockerfile
+++ b/builds/pb-jupyter-datascience.dockerfile
@@ -20,6 +20,11 @@ ENV HOME /home/$NB_USER
 COPY scripts/jupyter/autodownload_and_start.sh /usr/local/bin/autodownload_and_start.sh
 RUN chmod a+x /usr/local/bin/autodownload_and_start.sh
 
+RUN echo "ssh-client and less from apt" \
+    && apt-get update \
+    && apt-get install -y ssh-client less \
+    && apt-get clean
+
 # compatibility with old blueprints, remove when not needed
 RUN ln -s /usr/local/bin/autodownload_and_start.sh /usr/local/bin/bootstrap_and_start.bash
 

--- a/builds/pb-jupyter-minimal.dockerfile
+++ b/builds/pb-jupyter-minimal.dockerfile
@@ -18,6 +18,11 @@ ENV HOME /home/$NB_USER
 COPY scripts/jupyter/autodownload_and_start.sh /usr/local/bin/autodownload_and_start.sh
 RUN chmod a+x /usr/local/bin/autodownload_and_start.sh
 
+RUN echo "ssh-client and less from apt" \
+    && apt-get update \
+    && apt-get install -y ssh-client less \
+    && apt-get clean
+
 USER $NB_USER
 
 CMD ["/usr/local/bin/autodownload_and_start.sh"]

--- a/builds/pb-jupyter-ml.dockerfile
+++ b/builds/pb-jupyter-ml.dockerfile
@@ -18,6 +18,11 @@ ENV HOME /home/$NB_USER
 COPY scripts/jupyter/autodownload_and_start.sh /usr/local/bin/autodownload_and_start.sh
 RUN chmod a+x /usr/local/bin/autodownload_and_start.sh
 
+RUN echo "ssh-client and less from apt" \
+    && apt-get update \
+    && apt-get install -y ssh-client less \
+    && apt-get clean
+
 RUN echo "graphviz from apt" \
     && apt-get update \
     && apt-get install -y graphviz \

--- a/builds/pb-jupyter-pyspark.dockerfile
+++ b/builds/pb-jupyter-pyspark.dockerfile
@@ -18,6 +18,11 @@ ENV HOME /home/$NB_USER
 COPY scripts/jupyter/autodownload_and_start.sh /usr/local/bin/autodownload_and_start.sh
 RUN chmod a+x /usr/local/bin/autodownload_and_start.sh
 
+RUN echo "ssh-client and less from apt" \
+    && apt-get update \
+    && apt-get install -y ssh-client less \
+    && apt-get clean
+
 USER $NB_USER
 
 CMD ["/usr/local/bin/autodownload_and_start.sh"]


### PR DESCRIPTION
Sometimes Jupyter terminal is used as a light weight Linux environment
on courses. Add ssh client and less for this purpose.