### PR TITLE
Build script enhancements

### DIFF
--- a/builds/build.sh
+++ b/builds/build.sh
@@ -3,7 +3,11 @@
 set -e
 
 repository=${TAG_REPOSITORY:-'csc'}
+
+# set filter
 filter=${1:-'*'}
+# remove trailing .dockerfile from filter, if exists
+filter=${filter%.dockerfile}
 
 for dockerfile in $filter.dockerfile; do
 

--- a/builds/build_openshift.sh
+++ b/builds/build_openshift.sh
@@ -2,11 +2,10 @@
 
 set -e
 
-if [ ! -z "$1" ]; then
-    filter=$1
-else
-    filter='*'
-fi
+# set filter
+filter=${1:-'*'}
+# remove trailing .dockerfile from filter, if exists
+filter=${filter%.dockerfile}
 
 for dockerfile in $filter.dockerfile; do
 

--- a/builds/pb-jupyter-r-keras.dockerfile
+++ b/builds/pb-jupyter-r-keras.dockerfile
@@ -1,0 +1,41 @@
+FROM jupyter/r-notebook
+
+MAINTAINER Olli Tourunen <olli.tourunen@csc.fi>
+
+USER root
+
+# OpenShift allocates the UID for the process, but GID is 0
+# Based on an example by Graham Dumpleton
+RUN chgrp -R root /home/$NB_USER \
+    && find /home/$NB_USER -type d -exec chmod g+rwx,o+rx {} \; \
+    && find /home/$NB_USER -type f -exec chmod g+rw {} \; \
+    && chgrp -R root /opt/conda \
+    && find /opt/conda -type d -exec chmod g+rwx,o+rx {} \; \
+    && find /opt/conda -type f -exec chmod g+rw {} \;
+
+RUN ln -s /usr/bin/env /bin/env
+
+ENV HOME /home/$NB_USER
+
+COPY scripts/jupyter/autodownload_and_start.sh /usr/local/bin/autodownload_and_start.sh
+RUN chmod a+x /usr/local/bin/autodownload_and_start.sh
+
+RUN echo "ssh-client and less from apt" \
+    && apt-get update \
+    && apt-get install -y ssh-client less \
+    && apt-get clean
+
+# compatibility with old blueprints, remove when not needed
+RUN ln -s /usr/local/bin/autodownload_and_start.sh /usr/local/bin/bootstrap_and_start.bash
+
+USER $NB_USER
+
+# install tensorflow
+RUN pip --no-cache-dir install tensorflow==2.2.0
+
+# install R keras
+RUN R -e 'install.packages("vioplot", repo="http://cran.rstudio.com/")' \
+ && R -e 'install.packages("devtools", repo="http://cran.rstudio.com/")' \
+ && R -e 'devtools::install_github("rstudio/keras", ref = "2.3.0.0", upgrade = "always")'
+
+CMD ["/usr/local/bin/autodownload_and_start.sh"]


### PR DESCRIPTION
strip filter .dockerfile extension automatically

This makes it easier to use tab completion and wildcards from command line.

#27 needs to go in first, this is optimistically based on that